### PR TITLE
refactor: bring build time fix, Sidebar bugfix, test fix and commit-msg fix to team-4-stable (SCRUM-78)

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,13 +1,18 @@
-#!/bin/bash
-
+#!/bin/sh
 commit_message_file="$1"
-commit_message=$(head -n 1 "$commit_message_file") # Read only the first line
-valid_commit_regex='^([Rr]efactor|[Ff]eature|[Ff]eat|[Bb]ugfix|[Dd]ocs|[Cc]hore|[Bb]ug|[Hh]otfix): .+ \([A-Z]+-[0-9]+(, *[A-Z]+-[0-9]+)*\)$'
+commit_message_file=$(echo "$commit_message_file" | tr -d '\r') # Remove carriage returns
+commit_message=$(head -n 1 "$commit_message_file")
 
-if [[ ! "$commit_message" =~ $valid_commit_regex ]]; then
-  echo "Error: Commit message must match agreed on format."
-  echo "Example. refactor: your commit summary (TI-12, TI-23)"
+if ! awk -v msg="$commit_message" '
+BEGIN {
+  pattern = "^(Refactor|Feature|Feat|Bugfix|Docs|Chore|Bug|Hotfix|refactor|feature|feat|bugfix|docs|chore|bug|hotfix): .+ \\([A-Z]+-[0-9]+(, [A-Z]+-[0-9]+)*\\)$"
+  if (msg ~ pattern) {
+    exit 0
+  } else {
+    exit 1
+  }
+}'; then
+  echo "❌ Error: Commit message must match format."
+  echo "   Example: refactor: some message (TI-123)"
   exit 1
 fi
-
-exit 0

--- a/e2e/initE2EMocked.ts
+++ b/e2e/initE2EMocked.ts
@@ -1,15 +1,10 @@
-// e2e/initE2EMocked.ts
 import type { Page, TestInfo } from '@playwright/test';
 
 export async function initE2EMocked(page: Page, testInfo: TestInfo): Promise<void> {
 	const isMockedFromEnv = testInfo.project?.use?.launchOptions?.env?.E2E_MOCKED === 'true';
 
-	await page.evaluate((isMocked) => {
-		window.E2E_MOCKED = isMocked;
-		console.log(isMocked);
-		console.log(window.E2E_MOCKED);
-		// Helps create a global variable so AppContainer can access it,
-		// which results in it knowing if it's going to use the mock version or not.
+	await page.addInitScript(mock => {
+		window.E2E_MOCKED = mock;
 	}, isMockedFromEnv);
 }
 

--- a/src/lib/components/InputTable.svelte
+++ b/src/lib/components/InputTable.svelte
@@ -2,7 +2,7 @@
 	import type { RequestVariable } from '../types/RequestVariable';
 	import type { ResponsePattern } from '../types/ResponsePattern';
 	import type { InputTablePrompt } from '../types/InputTablePrompt';
-	import { Trash2Icon } from 'lucide-svelte';
+	import Trash2Icon from 'lucide-svelte/icons/trash-2';
 
 	//There is a discriminated union type that determines the kind of input the table receives
 	let { prompt }: { prompt: InputTablePrompt } = $props();
@@ -162,7 +162,7 @@
 							class="ml-2 hidden items-center justify-center group-hover:flex"
 						>
 							<button onclick={() => deleteRow(index)}>
-								<Trash2Icon />
+								<Trash2Icon class="shrink-0 text-inherit" />
 							</button>
 						</div>
 					</th>
@@ -197,7 +197,7 @@
 							class="ml-2 hidden items-center justify-center group-hover:flex"
 						>
 							<button onclick={() => deleteRow(index)}>
-								<Trash2Icon />
+								<Trash2Icon class="shrink-0 text-inherit" />
 							</button>
 						</div>
 					</th>

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	import { PanelRightIcon, HomeIcon, ClockIcon, PlusIcon, UserIcon } from 'lucide-svelte';
+	import PanelRightIcon from 'lucide-svelte/icons/panel-right';
+	import HomeIcon from 'lucide-svelte/icons/home';
+	import ClockIcon from 'lucide-svelte/icons/clock';
+	import PlusIcon from 'lucide-svelte/icons/plus';
+	import UserIcon from 'lucide-svelte/icons/user';
+
 	let collapsed = false;
 
 	function toggleCollapse() {
@@ -12,7 +17,7 @@
 	style="left: {collapsed ? '4.5rem' : '13.5rem'}"
 >
 	<button on:click={toggleCollapse} aria-label="Expandir o colapsar menú">
-		<PanelRightIcon size={24} color="black" />
+		<PanelRightIcon size={24} color="black" class="text-inherit" />
 	</button>
 </div>
 
@@ -31,9 +36,9 @@
 						? 'justify-center'
 						: ''}"
 				>
-					<HomeIcon size={24} color="white" />
+					<HomeIcon size={24} color="white" class="shrink-0 text-inherit" />
 					{#if !collapsed}
-						<span class="text-white">Home</span>
+						<span class="inline text-white">Home</span>
 					{/if}
 				</div>
 			</a>
@@ -44,7 +49,7 @@
 						? 'justify-center'
 						: ''}"
 				>
-					<ClockIcon size={24} color="white" />
+					<ClockIcon size={24} color="white" class="shrink-0 text-inherit" />
 					{#if !collapsed}
 						<span class="text-white">History</span>
 					{/if}
@@ -57,7 +62,7 @@
 						? 'justify-center'
 						: ''}"
 				>
-					<PlusIcon name="Plus" size={24} color="white" />
+					<PlusIcon name="Plus" size={24} color="white" class="shrink-0 text-inherit" />
 					{#if !collapsed}
 						<span class="text-white">Create</span>
 					{/if}
@@ -67,7 +72,7 @@
 		<!-- Usuario -->
 		<div class="flex items-center p-4 text-white">
 			<div class="flex h-8 w-8 items-center justify-center rounded-full bg-white/20">
-				<UserIcon name="User" size={24} color="white" />
+				<UserIcon name="User" size={24} color="white" class="shrink-0 text-inherit" />
 			</div>
 			{#if !collapsed}
 				<span class="ml-3">Username</span>

--- a/src/lib/components/UsernameButton.svelte
+++ b/src/lib/components/UsernameButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import AccountDropdownMenu from '$lib/components/AccountDropdownMenu.svelte';
-	import { UserIcon } from 'lucide-svelte';
+	import UserIcon from 'lucide-svelte/icons/user';
 
 	let username: string = $state('John Doe');
 	let email: string = $state('some@domain.com');

--- a/src/lucide.d.ts
+++ b/src/lucide.d.ts
@@ -1,0 +1,9 @@
+// This might be the closest thing to a "correct" Icon component
+// (because Vite doesn't care about tree shaking in dev mode)
+declare module 'lucide-svelte/icons' {
+	import { LucideProps } from 'lucide-svelte/dist/types.d.ts';
+	import { SvelteComponent } from 'svelte';
+	const cmp: SvelteComponent<LucideProps>;
+
+	export = cmp;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
 		"playwright.config.ts",
 		"vitest-setup-client.ts",
 		"app.d.ts",
+		"lucide.d.ts",
 		"ambient.d.ts",
 		"non-ambient.d.ts",
 		".svelte-kit/types/**/$types.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,17 @@
 import tailwindcss from '@tailwindcss/vite';
+import { fileURLToPath, URL } from 'node:url';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			'lucide-svelte/icons': fileURLToPath(
+				new URL('./node_modules/lucide-svelte/dist/icons', import.meta.url)
+			)
+		}
+	},
 	plugins: [tailwindcss(), sveltekit()],
 	test: {
 		workspace: [


### PR DESCRIPTION
- Return sidebar icons to their MVP version (they were getting shrunk due to the parent flex container)
- Implement custom import of lucide icons by file, improving build times MASSIVELY
- Add new gobal file where the "lucide-svelte/icons" component is included
- Fix the test initialization script not working